### PR TITLE
Fix combination count check for fourth order searches

### DIFF
--- a/BitEpi.cpp
+++ b/BitEpi.cpp
@@ -2278,7 +2278,7 @@ public:
 		for (uint32 i = 0; i < numThread; i++)
 		{
 			pthread_join(threads[i], NULL);
-			if (args.jobs[td[i].jobId].counted != args.jobs[td[i].jobId].comb)
+			if (args.jobs[td[i].jobId].counted != round(args.jobs[td[i].jobId].comb))
 			{
 				printf("\n >>> counted: %llu expected %15.0f", args.jobs[td[i].jobId].counted, args.jobs[td[i].jobId].comb);
 				ERROR("Problem in parallelisation please report on GitHub issue page");


### PR DESCRIPTION
The program terminates with an error when checking the total number of combinations explored due to differences in precision between double precision types and unsigned integers.

When I run ` ./BitEpi -bfile -i sampleData/bfile.bed -t 1 -b4 1 -o test.txt` using the sample data sets, I obtain:

```

=============Start=============




=========================================
 Given Arguments:
 input                sampleData/bfile.bed
 output               test.txt
 threads              1
 beta4                1.000000

=========================================

loading dataset sampleData/bfile.bed, sampleData/bfile.bim, sampleData/bfile.fam
There are 100 SNPs
There are 2000 samples
There are 1000 Cases
There are 1000 Controls

 Purity of the whole dataset (B_0) is 0.500000 (baseline for Beta)

 Shift dataset by 2 bits compeleted
 Shift dataset by 4 bits compeleted
 Shift dataset by 6 bits compeleted
 >>>>>> 4-SNP exhaustive search

 Processing 1 jobs [0..0] in parallel
 Total   number of 4-SNP combinations to be tested:                      3921225
 Total   number of jobs:                                                       1
 Average number of combintions to be tested in each job:                 3921225

 Breaking the program into similar sized jobs
 Outer  loop iterates from S1 to E1
 Second loop iterates from S2 to E2
 Combinations   : SNP combinations to be tested in each job
 diffToAvg      : Difference to average number of combination to be tested in each job
 AccumDiffToAvg : Accumulative diffToAvg
 Job ID (    S1,    S2) (    E1,    E2)    Combinations       diffToAvg  AccumDiffToAvg
      1 (     1,     2) (    97,    98)         3921225               0               0

 Thread     1 processing Job     1 ...

 Thread     1 processed Job     1 in      4.663 seconds (    840925 tests per second)

3921225
3921224

 >>> counted: 3921225 expected         3921225
 *** ERROR: Problem in parallelisation please report on GitHub issue page (line:2290 - File BitEpi_copy.cpp)
```

The problematic line is:
https://github.com/aehrc/BitEpi/blob/a23e2ad1e7a5f6592b8e32b5ca30bb1945af94d4/BitEpi.cpp#L2281

If you compare integers and doubles like that, a small diference in precision carried over numerous operations may change the boolean outcome. The commit included in this pull request fixes this problem.
